### PR TITLE
Fix issue with finding correct pin count

### DIFF
--- a/src/main/java/nl/juraji/pinterestdownloader/executors/FetchPinsExecutor.java
+++ b/src/main/java/nl/juraji/pinterestdownloader/executors/FetchPinsExecutor.java
@@ -105,7 +105,7 @@ public class FetchPinsExecutor extends PinterestWebExecutor<List<Pin>> {
         WebElement pinCountElement = getElement(ScraperData.by("xpath.boardPins.pinCount"));
         if (pinCountElement != null) {
             String count = pinCountElement.getText()
-                    .replace(" pins", "")
+                    .replace(" Pins", "")
                     .replace(".", "");
 
             return Integer.parseInt(count);


### PR DESCRIPTION
Pinterest uses capitalized `Pin` instead of `pin` which caused the count to exception